### PR TITLE
Add request context for tracing in Loki logging

### DIFF
--- a/src/loki/LokiLogger.js
+++ b/src/loki/LokiLogger.js
@@ -29,6 +29,8 @@
 
 'use strict';
 
+var lokiRequestContext = require('./request-context');
+
 var BASE_BACKOFF_MS       = 1000;
 var MAX_BACKOFF_MS        = 30000;
 var MAX_FIELD_JSON_LENGTH = 10000;
@@ -98,6 +100,13 @@ LokiLogger.prototype.logConsole = function(level, message, stackTrace) {
       message:   message,
     };
     if (stackTrace) entry.stackTrace = stackTrace;
+    // Tag console output with the trace context of the in-flight request so
+    // it correlates with the route log in Grafana (set by loki-middleware).
+    var ctx = lokiRequestContext.getStore();
+    if (ctx) {
+      if (ctx.traceId) entry.traceId = ctx.traceId;
+      if (ctx.spanId)  entry.spanId  = ctx.spanId;
+    }
     this._enqueue({ level: normalizedLevel, source: 'console' }, entry);
   } catch (e) {
     // swallow — prevent loops

--- a/src/loki/loki-middleware.js
+++ b/src/loki/loki-middleware.js
@@ -26,6 +26,7 @@
 'use strict';
 
 const LokiLogger = require('./LokiLogger');
+const lokiRequestContext = require('./request-context');
 
 let lokiLogger;
 let _initialized = false;
@@ -66,6 +67,12 @@ function lokiMiddleware(req, res, next) {
   if (SKIP_PATHS.some(p => urlPath === p || urlPath.startsWith(p + '?'))) {
     return next();
   }
+
+  // Trace context forwarded by the API server (see parse-request-context.js).
+  // Logging these lets a single Grafana search by traceId correlate this
+  // parse-server request back to the originating API request.
+  const traceId = req.headers['x-trace-id'];
+  const spanId  = req.headers['x-span-id'];
 
   const startTime = Date.now();
 
@@ -110,6 +117,8 @@ function lokiMiddleware(req, res, next) {
       if (apiRequestId)     meta.apiRequestId     = apiRequestId;
       if (apiRoute)         meta.apiRoute         = apiRoute;
       if (apiOriginalRoute) meta.apiOriginalRoute = apiOriginalRoute;
+      if (traceId)          meta.traceId          = traceId;
+      if (spanId)           meta.spanId           = spanId;
       if (parsedRoute.functionName) meta.functionName = parsedRoute.functionName;
       if (parsedRoute.objectId) meta.objectId = parsedRoute.objectId;
 
@@ -129,7 +138,16 @@ function lokiMiddleware(req, res, next) {
     }
   });
 
-  next();
+  // Run the rest of the request inside an async context carrying the trace
+  // ids so console.* logs emitted while handling it are tagged with the same
+  // traceId/spanId (resolved in LokiLogger.logConsole).
+  if (traceId) {
+    lokiRequestContext.run({ traceId: traceId, spanId: spanId }, function () {
+      next();
+    });
+  } else {
+    next();
+  }
 }
 
 /**

--- a/src/loki/request-context.js
+++ b/src/loki/request-context.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/**
+ * Shared request-scoped context for Loki logging.
+ *
+ * The loki-middleware wraps each incoming request in lokiRequestContext.run()
+ * with the trace context forwarded by the API server (X-Trace-Id / X-Span-Id).
+ * This lets console.* logs emitted while handling the request resolve the
+ * originating traceId — so a single Grafana search by traceId surfaces both
+ * the route log and any console output produced for that request.
+ */
+
+const { AsyncLocalStorage } = require('async_hooks');
+
+const lokiRequestContext = new AsyncLocalStorage();
+
+module.exports = lokiRequestContext;


### PR DESCRIPTION
- Introduced `request-context.js` to manage request-scoped context.
- Updated `LokiLogger` to include traceId and spanId in console logs.
- Enhanced `loki-middleware` to forward trace context from API requests.